### PR TITLE
docs: fix link for "Generative AI System Design Interview"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 > [System Design Interview, An Insider's Guide, Second Edition - by Alex Xu, 2020](https://www.amazon.com/System-Design-Interview-insiders-Second/dp/B08CMF2CQF) | [__PDF Notes-Chinese__](https://github.com/junfanz1/Quant-Books-Notes/blob/main/System%20Design/Notes%20on%20System%20Design.pdf)
 
-> [Generative AI System Design Interview - by Ali Aminian, Hao Sheng, 2024](https://www.amazon.com/Machine-Learning-System-Design-Interview/dp/1736049127) | [__Markdown Notes__](https://github.com/junfanz1/AI-LLM-ML-CS-Quant-Review/blob/main/System%20Design/GenAI%20System%20Design%20Interview.md)
+> [Generative AI System Design Interview - by Ali Aminian, Hao Sheng, 2024](https://www.amazon.com/Generative-AI-System-Design-Interview/dp/1736049143) | [__Markdown Notes__](https://github.com/junfanz1/AI-LLM-ML-CS-Quant-Review/blob/main/System%20Design/GenAI%20System%20Design%20Interview.md)
 
 > [Machine Learning System Design Interview - by Ali Aminian, Alex Xu, 2023](https://www.amazon.com/Machine-Learning-System-Design-Interview/dp/1736049127) | [__Markdown Notes__](https://github.com/junfanz1/AI-LLM-ML-CS-Quant-Review/blob/main/System%20Design/ML%20System%20Design%20Interview.md)
 


### PR DESCRIPTION
What: Updated README to point “Generative AI System Design Interview” to the correct official URL.  
Why: Current link is misdirected.  
Change: Replaced https://www.amazon.com/Machine-Learning-System-Design-Interview/dp/1736049127 with https://www.amazon.com/Generative-AI-System-Design-Interview/dp/1736049143.  
Testing: Manually verified the new link.  
Closes: #1 
